### PR TITLE
Reversed the instruction for self init

### DIFF
--- a/content/docs/introduction.md
+++ b/content/docs/introduction.md
@@ -23,7 +23,7 @@ $ hygen mailer new
 Here's a quick run-down to get to your own generator:
 
 ```bash
-$ hygen self init
+$ hygen init self
 $ hygen generator new --name awesome-generator
 $ hygen awesome-generator new --name hello
 ```


### PR DESCRIPTION
The instruction for initializing in the project were simply reversed.  The error that is thrown tells you to use it the other way around.