### PR TITLE
feature: add unless exists option to add operation

### DIFF
--- a/src/__tests__/metaverse.spec.js
+++ b/src/__tests__/metaverse.spec.js
@@ -62,8 +62,9 @@ describe('metaverse', () => {
       ['worker', 'new', '--name', 'foo'],
       ['shell', 'new', '--name', 'foo'],
       ['inflection', 'new', '--name', 'person'],
-      ['conditional-rendering', 'new', '--notGiven']
+      ['conditional-rendering', 'new', '--notGiven'],
+      ['add-unless-exists', 'new', '--message', 'foo']
     ],
-    { name: 'message', message: 'foo' }
+    { name: 'message', message: 'foo', overwrite: true }
   )
 })

--- a/src/__tests__/metaverse/hygen-templates/_templates/add-unless-exists/new/always.ejs.t
+++ b/src/__tests__/metaverse/hygen-templates/_templates/add-unless-exists/new/always.ejs.t
@@ -1,0 +1,4 @@
+---
+to: given/add-unless-exists/<%= message || 'unnamed' %>/always.txt
+---
+This file is already there

--- a/src/__tests__/metaverse/hygen-templates/_templates/add-unless-exists/new/y_overwrite.ejs.t
+++ b/src/__tests__/metaverse/hygen-templates/_templates/add-unless-exists/new/y_overwrite.ejs.t
@@ -1,0 +1,4 @@
+---
+to: given/add-unless-exists/<%= message || 'unnamed' %>/always.txt
+---
+This file should overwrite the other

--- a/src/__tests__/metaverse/hygen-templates/_templates/add-unless-exists/new/z_dont-overwrite.ejs.t
+++ b/src/__tests__/metaverse/hygen-templates/_templates/add-unless-exists/new/z_dont-overwrite.ejs.t
@@ -1,0 +1,5 @@
+---
+to: given/add-unless-exists/<%= message || 'unnamed' %>/always.txt
+unless_exists: true
+---
+This file should never be written

--- a/src/__tests__/metaverse/hygen-templates/expected/add-unless-exists/foo/always.txt
+++ b/src/__tests__/metaverse/hygen-templates/expected/add-unless-exists/foo/always.txt
@@ -1,0 +1,1 @@
+This file should overwrite the other

--- a/src/ops/add.js
+++ b/src/ops/add.js
@@ -9,7 +9,7 @@ const add = async (action: RenderedAction, args, { logger, cwd }) => {
     return
   }
   const absTo = path.join(cwd, to)
-  const shouldNotOverwrite = (typeof unless_exists !== 'undefined') && unless_exists === true
+  const shouldNotOverwrite = unless_exists !== undefined && unless_exists === true
 
   if (await fs.exists(absTo)) {
     if (

--- a/src/ops/add.js
+++ b/src/ops/add.js
@@ -4,14 +4,16 @@ const path = require('path')
 const fs = require('fs-extra')
 const { red } = require('chalk')
 const add = async (action: RenderedAction, args, { logger, cwd }) => {
-  const { attributes: { to, inject } } = action
+  const { attributes: { to, inject, unless_exists } } = action
   if (!to || inject) {
     return
   }
   const absTo = path.join(cwd, to)
+  const shouldNotOverwrite = (typeof unless_exists !== 'undefined') && unless_exists === true
 
   if (await fs.exists(absTo)) {
     if (
+      shouldNotOverwrite ||
       !await inquirer
         .prompt({
           prefix: '',


### PR DESCRIPTION
Added a feature to the add operation to only execute unless the file already exists.

### Motivation for this feature
When generating code it is necessary to not only generate the new code but also use injections to "register" it in other parts of the application. This works fine by using the inject feature. 
But it only works correctly when the target file with the base structure is already there, which is not ensured. 
In these cases someone would like to write a template that ensures the scaffold is produced before and do the injection in another template for the actual "registration". 

**For example:**
Assume you have the following application structure:
```
app
├ modules
  ├ my_module
    ├ controllers
      ├ controllerA.js
    ├ tests
     ├ suite.js
     ├ controllerA.spec.js
```
Its easy to build a generator that creates a new "controllerB" in my_module/controllers and its test int my_module/tests and also inject the controllerB.spec.js registration in the suite.js.

But maybe the my_module doesn't have tests and a suite.js file yet. I would need to create a completely new generator just so that i have one that also generates the suite.js.

Therefore I could use a unless_exists to only run a template for scaffolding the suite.js when it doesn't exist, but also reuse all the other templates no matter if its a brand new (aka empty) module or I want to make an addition to an existing module.

### Docs
The docs are missing yet. I would write a doc part for it when you are fine with the feature and its not against the project goals.  