### PR TITLE
docs: Fixed image links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h3 align="center">
-  <img src="media/hygen.png" alt="hygen logo" width=400 />
+  <img src="//raw.githubusercontent.com/jondot/hygen/master/media/hygen.png" alt="hygen logo" width=400 />
 </h3>
 
 [![build status](https://img.shields.io/travis/jondot/hygen/master.svg)](https://travis-ci.org/jondot/hygen)
@@ -8,7 +8,7 @@
 `hygen` is the simple, fast, and scalable code generator that lives _in_ your project.
 
 <div align="center">
-  <img src="media/hygen.gif" width=600/>
+  <img src="//raw.githubusercontent.com/jondot/hygen/master/media/hygen.gif" width=600/>
 </div>
 
 ## Quick Start


### PR DESCRIPTION
Using githubusercontent urls so that images on https://www.npmjs.com/package/hygen are not broken anymore