### PR TITLE
Docs: added "Ecosystem" reference to hygen-create

### DIFF
--- a/content/docs/create.md
+++ b/content/docs/create.md
@@ -1,0 +1,61 @@
+---
+title: "Create"
+doc: 2
+section: 2
+category: "tech"
+type: "doc"
+---
+
+Manually authoring a code generator is a pain. None of the tools that help you write code directly - such as language-sensitive IDEs, debuggers, unit testing frameworks, etc. - play nice when you author a generator. If you have a bug in the generator, you need to modify your templates, run the modified generator to create code, debug the result, and then manually import your changes back into the templates while remembering to replace keywords with ejs placeholders.
+
+[`hygen-create`](https://github.com/ronp001/hygen-create) offers a different approach to creating new generators: take an existing piece of code and automatically transform it into a generator.
+
+To create a generator using [`hygen-create`](https://github.com/ronp001/hygen-create):
+* Start a [`hygen-create`](https://github.com/ronp001/hygen-create) session
+* Select files to include in the generator
+* Specify a string to automatically turn into ejs snippets in the resulting templates
+* Run [`$ hygen-create generate`](https://github.com/ronp001/hygen-create)
+
+That's it!  Your new `hygen` generator is ready, and you can use it to create new "instances" of the code you generalized.  If something's not right, you can fix the problem directly in the generated code, then run [`hygen-create`](https://github.com/ronp001/hygen-create) on the modified code to update the generator with your fix.  It even remembers which files were originally included in the generator, so you don't have to select files all over again.
+
+For more details see [`https://github.com/ronp001/hygen-create`](https://github.com/ronp001/hygen-create)
+
+
+## Installation
+
+```bash
+$ yarn global add hygen-create
+```
+or
+```bash
+$ npm install --global hygen-create
+```
+
+
+## Key Features
+
+* String variations (UPPERCASED, CamelCased, etc.) are automatically recognized.  For example:
+```json
+// if the following 'package.json' is used as a generator source 
+// with 'MyPackage' as the templatization string:
+{
+    "name": "MyPackage",
+    "index": "my-package/bin/my_package.js"
+}
+```
+```json
+// the resulting generator with '--name NewUnit' will create:
+{
+    "name": "NewUnit",
+    "index": "new-unit/bin/new_unit.js"
+}
+```
+* Directory hierarchy is maintained
+* Gradually add files to the generator in a git-like fashion
+* Review auto-inserted ejs placeholders with a built-in colorized diff
+* Iteratively author generators by running [`hygen-create`](https://github.com/ronp001/hygen-create) again on the code created by the generator.
+
+
+## GitHub Project
+
+[`https://github.com/ronp001/hygen-create`](https://github.com/ronp001/hygen-create)

--- a/content/docs/create.md
+++ b/content/docs/create.md
@@ -6,9 +6,9 @@ category: "tech"
 type: "doc"
 ---
 
-Manually authoring a code generator is a pain. None of the tools that help you write code directly - such as language-sensitive IDEs, debuggers, unit testing frameworks, etc. - play nice when you author a generator. If you have a bug in the generator, you need to modify your templates, run the modified generator to create code, debug the result, and then manually import your changes back into the templates while remembering to replace keywords with ejs placeholders.
+Maintaining code generators over time can be a challenge in some cases. If you have a bug in the generator, you need to modify your templates, run the modified generator, and then manually import your changes back into the templates while remembering to replace keywords with ejs placeholders.
 
-[`hygen-create`](https://github.com/ronp001/hygen-create) offers a different approach to creating new generators: take an existing piece of code and automatically transform it into a generator.
+[`hygen-create`](https://github.com/ronp001/hygen-create) offers an approach to creating new generators: take an existing piece of code and automatically transform it into a generator.
 
 To create a generator using [`hygen-create`](https://github.com/ronp001/hygen-create):
 * Start a [`hygen-create`](https://github.com/ronp001/hygen-create) session


### PR DESCRIPTION
Added ```create.md``` into the content/docs directory -- hope that's the right thing to do.  It seemed to work well when I ran ```yarn docs:watch``` (i.e., the new page showed up), but since I'm not familiar with Gatsby I may have missed some key points.  Please let me know if I should change anything.

I opted to keep the description at a very high level, and leave the details in the project's README file. This way I won't have to bother you with a PR every time a make a small change to the documentation - only when there's something major.