### PR TITLE
Fix at_line reference & add missing generator in the docs

### DIFF
--- a/content/docs/introduction.md
+++ b/content/docs/introduction.md
@@ -83,7 +83,7 @@ Loaded templates: src/templates
 This creates a project-local `_templates` folder for you at your source root with two helper generators that saves you time:
 
 * `hygen generator new --name generatorName` - builds a new generator for you
-* `hygen with-prompt new --name generatorName` - the same as before, only this one will be prompt driven.
+* `hygen generator with-prompt new --name generatorName` - the same as before, only this one will be prompt driven.
 
 [[info]]
 |###### Template Locality

--- a/content/docs/templates.md
+++ b/content/docs/templates.md
@@ -223,7 +223,7 @@ Here are the available properties for an `inject: true` template:
 
 * `before` or `after` which contain a regular expression of text to locate. The inject line will appear `before` or `after` the located line.
 * `prepend` or `append`, when true, add a line to start or end of file respectively.
-* `line_at` which contains a line number will add a line at this exact line number.
+* `at_line` which contains a line number will add a line at this exact line number.
 
 In almost all cases you want to ensure you're not injecting content twice:
 


### PR DESCRIPTION
So, just started to use your awesome creation!
And as I traversed through the docs found those two issue and fixed in a blink.

Also, maybe the menu order is fliped? Right now the _Templates_ are the 2nd menu item, even tho it feels like you have to read about _Generators_ first to understand what's happening, and there is a line in the generators docs 
> We'll see more of these in templates.

So, I think this order would be more suitable.

- Quick Start
- Generators
- Templates

Cheers, and keep up this good work! Gona contrib later as I get more used to the library, already has some idea to implement ;)