### PR TITLE
Add eof_last attribute to inject options

### DIFF
--- a/src/__tests__/__snapshots__/injector.spec.js.snap
+++ b/src/__tests__/__snapshots__/injector.spec.js.snap
@@ -44,6 +44,17 @@ exports[`injector before rails 1`] = `
     "
 `;
 
+exports[`injector if eof_last is false trim eof last empty line from injection 1`] = `
+"
+    source 'http://rubygems.org'
+    gem 'rails'
+    gem 'kamikaze' # added by hygen
+    gem 'nokogiri'
+    gem 'httparty'
+
+    "
+`;
+
 exports[`injector prepend top of file 1`] = `
 "    gem 'kamikaze' # added by hygen
 

--- a/src/__tests__/injector.spec.js
+++ b/src/__tests__/injector.spec.js
@@ -86,4 +86,18 @@ describe('injector', () => {
       )
     ).toMatchSnapshot()
   })
+  it('if eof_last is false trim eof last empty line from injection', () => {
+    expect(
+      injector(
+        {
+          attributes: {
+            after: "gem 'rails'",
+            eof_last: false
+          },
+          body: "    gem 'kamikaze' # added by hygen\n"
+        },
+        gemfile
+      )
+    ).toMatchSnapshot()
+  })
 })

--- a/src/ops/injector.js
+++ b/src/ops/injector.js
@@ -4,15 +4,23 @@ import type { RenderedAction } from '../types'
 const L = require('lodash')
 
 const injector = (action: RenderedAction, content: string): string => {
-  const { attributes: { skip_if }, attributes, body } = action
+  const { attributes: { skip_if, eof_last }, attributes, body } = action
   const lines = content.split('\n')
   //eslint-disable-next-line
   const shouldSkip = skip_if && !!L.find(lines, _ => _.match(skip_if))
 
   if (!shouldSkip) {
     const idx = indexByLocation(attributes, lines)
+    //eslint-disable-next-line
+    const trimEOF = eof_last === false && /\r?\n$/.test(body);
     if (idx >= 0) {
-      lines.splice(idx, 0, body)
+      lines.splice(
+        idx,
+        0,
+        trimEOF
+          ? body.replace(/\r?\n$/, '')
+          : body
+      )
     }
   }
   return lines.join('\n')


### PR DESCRIPTION
Hello!
I feeling some pain because my editor paste empty line on the end of file after save and after injection I recieving terrible files.
```css
@import 'foo'
/* Inject here */
@import 'baz' /* injected */

@import 'bar'
```
So, I think `eof_last` attribute must be really useful. If you set `false` to it, empty line at the end of injection body will be removed.

For example:
```
---
to: main.css
inject: true
after: \/\* Inject here \*\/
eof_last: false
---
```
Result must be like this:
```
```css
@import 'foo'
/* Inject here */
@import 'baz' /* injected */
@import 'bar'
```