### PR TITLE
support for matching `before`, `after`, and `skip_if` attributes that span newlines

### DIFF
--- a/content/docs/faq.md
+++ b/content/docs/faq.md
@@ -20,6 +20,19 @@ to: app/reducers/<%= reducer.toLowerCase() %>.js
 Hello <%= defaulted %>.
 ```
 
+
+## Can I inject using regular expressions that span across newlines in the target file?
+
+`hygen` is designed to work on a line-by-line basis. Injection inserts the _lines_ of the template _between lines_ (by `\n`) of the target file according to the expression supplied. 
+
+However, as of v2.1.2 or later, `hygen` supports multi-line regular expressions in the `before`, `after`, and `skip_if` injection properties.  This works in the following ways: 
+
+* `skip-if` is now always evaluated as a potentially multi-line expression across the entire target file.
+
+* `before` and `after` first try to match the expression within any single line of the target file. If no match is found, they then attempt a multi-line match.
+
+* `before` will inject before the line on which the match began, and `after` will inject after the line on which the match ended.
+
 ## I Want To Use Generators From a Single Place
 
 If you have several `_templates` locations throughout a project (let's say for a server and client), you might usually `cd` into each sub-project to use hygen like so:

--- a/src/__tests__/__snapshots__/injector.spec.js.snap
+++ b/src/__tests__/__snapshots__/injector.spec.js.snap
@@ -87,3 +87,36 @@ exports[`injector skip_if "source" exists 1`] = `
 
     "
 `;
+
+exports[`injector correctly interpret multi-line after regex 1`] = `
+"
+    source 'http://rubygems.org'
+    gem 'rails'
+    gem 'nokogiri'
+    gem 'kamikaze' # added by hygen
+    gem 'httparty'
+
+    "
+`;
+
+exports[`injector correctly interpret multi-line before regex 1`] = `
+"
+    source 'http://rubygems.org'
+    gem 'kamikaze' # added by hygen
+    gem 'rails'
+    gem 'nokogiri'
+    gem 'httparty'
+
+    "
+`;
+
+
+exports[`injector correctly interpret multi-line skip_if regex 1`] = `
+"
+    source 'http://rubygems.org'
+    gem 'rails'
+    gem 'nokogiri'
+    gem 'httparty'
+
+    "
+`;

--- a/src/__tests__/injector.spec.js
+++ b/src/__tests__/injector.spec.js
@@ -114,4 +114,46 @@ describe('injector', () => {
       )
     ).toMatchSnapshot()
   })
+  it('correctly interpret multi-line after regex', () => {
+    expect(
+      injector(
+        {
+          attributes: {
+            after: "rails[a-z\\:\\/\\.'\\s]*giri",
+            eof_last: false
+          },
+          body: "    gem 'kamikaze' # added by hygen"
+        },
+        gemfile
+      )
+    ).toMatchSnapshot()
+  })
+  it('correctly interpret multi-line before regex', () => {
+    expect(
+      injector(
+        {
+          attributes: {
+            before: "rails[a-z\\:\\/\\.'\\s]*giri",
+            eof_last: false
+          },
+          body: "    gem 'kamikaze' # added by hygen"
+        },
+        gemfile
+      )
+    ).toMatchSnapshot()
+  })
+  it('correctly interpret multi-line skip_if regex', () => {
+    expect(
+      injector(
+        {
+          attributes: {
+            skip_if: "rails[a-z\\:\\/\\.'\\s]*giri",
+            after: "gem 'rails'"
+          },
+          body: "    gem 'kamikaze' # added by hygen"
+        },
+        gemfile
+      )
+    ).toMatchSnapshot()
+  })
 })

--- a/src/ops/injector.js
+++ b/src/ops/injector.js
@@ -7,7 +7,7 @@ const injector = (action: RenderedAction, content: string): string => {
   const { attributes: { skip_if, eof_last }, attributes, body } = action
   const lines = content.split('\n')
   //eslint-disable-next-line
-  const shouldSkip = skip_if && !!L.find(lines, _ => _.match(skip_if))
+  const shouldSkip = skip_if && !!content.match(skip_if)
 
   if (!shouldSkip) {
     const idx = indexByLocation(attributes, lines)
@@ -28,13 +28,36 @@ const injector = (action: RenderedAction, content: string): string => {
   return lines.join('\n')
 }
 
-const before = (_, lines) => L.findIndex(lines, l => l.match(_))
+const getPragmaticIndex = (pattern, lines, isBefore) => {
+
+  const oneLineMatchIndex = L.findIndex(lines, l => l.match(pattern));
+
+  if (oneLineMatchIndex < 0) {
+    const fullText = lines.join('\n');
+    const fullMatch = fullText.match(new RegExp(pattern, "m"));
+  
+    if (fullMatch && fullMatch.length) {
+
+      if (isBefore) {
+        const fullTextUntilMatchStart = fullText.substring(0, fullMatch.index);
+        return fullTextUntilMatchStart.split('\n').length -1;
+      } else {
+        const matchEndIndex = fullMatch.index + fullMatch.toString().length;
+        const fullTextUntilMatchEnd = fullText.substring(0, matchEndIndex);
+        return fullTextUntilMatchEnd.split('\n').length;
+      }
+    }
+  }
+
+  return oneLineMatchIndex + (isBefore ? 0 : 1);
+}
+
 const locations = {
   at_line: _ => _,
   prepend: _ => 0,
   append: (_, lines) => lines.length - 1,
-  before,
-  after: (_, lines) => before(_, lines) + 1
+  before: (_, lines) => getPragmaticIndex(_, lines, true),
+  after: (_, lines) => getPragmaticIndex(_, lines, false)
 }
 const indexByLocation = (attributes: any, lines: Array<string>): number => {
   const pair = L.find(L.toPairs(attributes), ([k, v]) => locations[k])


### PR DESCRIPTION
This is just my quick crack at it.  Here are some notes:
- to ensure backwards-compatibility, the injector will use the existing line-by-line match behavior, and only use the new full-text matching behavior if the existing behavior does not match.
- the first thing the new matching does is `join` the lines back up again, which is inefficient; it would be much more reasonable to pass the original `content` into `indexByLocation`.  I just wanted to have as little/clear of a footprint as possible for this PR, so I didn't change that call signature, but you will probably want to do so. 
- The `skip_if` aspect of the support was a simple change that could have been done independently; as far as I could see, there wasn't any particular reason to be doing a lodash find of a regex match on each separate line of the content other than to be consistent with the other behavior, so I changed it to just call match on the whole content.  (I don't think this will have a negative performance impact, except perhaps in the case where `skip_if` exists and would have been matched relatively early in the document? idk.  If you think there might be a concern there, we could add a flag to select which behavior.)
- this PR would address #91.