### PR TITLE
recurse template subdirectories

### DIFF
--- a/src/__tests__/fixtures/app/action-multifiles-nest/arbitrarySubfolder/capitalized.ejs.t
+++ b/src/__tests__/fixtures/app/action-multifiles-nest/arbitrarySubfolder/capitalized.ejs.t
@@ -1,0 +1,4 @@
+---
+to: foo/<%= name %>/bar
+---
+<%= name %> and <%= Name %>

--- a/src/__tests__/fixtures/app/action-multifiles-nest/full.ejs.t
+++ b/src/__tests__/fixtures/app/action-multifiles-nest/full.ejs.t
@@ -1,0 +1,12 @@
+---
+to: foo/<%= name %>/bar
+---
+
+
+This is the html email template.
+Find me at <i>app/mailers/hello/html.ejs</i>
+
+<br/> 
+<br/> 
+
+You owe <%= bill %>

--- a/src/__tests__/render.spec.js
+++ b/src/__tests__/render.spec.js
@@ -52,6 +52,16 @@ describe('render ng', () => {
     expect(res[1].file).toMatch(/full/)
   })
 
+  it('render should include files sorted into subfolders', async () => {
+    const res = await render({
+      bill: 17,
+      actionfolder: fixture('app/action-multifiles-nest')
+    })
+    expect(res.length).toEqual(2)
+    expect(res[0].file).toMatch(/capitalized/)
+    expect(res[1].file).toMatch(/full/)
+  })
+
   it('render with subaction should filter only to that subaction', async () => {
     const res = await render({
       bill: 17,


### PR DESCRIPTION
This PR should allow an arbitrary directory structure below the action subfolder for templates, so that users have more options to organize their files.
I shamelessly ~stole~borrowed the core of this change from [this StackOverflow answer](https://stackoverflow.com/a/45130990).  
I don't think this will cause any significant performance issues (but I didn't do any large-load perf testing or anything... ymmv).
This would satisfy #28.
Note: I also added a couple of TODOs for some extra tests of unrelated functionality that should probably be added (only because I almost committed this without those lines, and the test suite didn't complain), but I didn't actually write those tests myself, because I'm lazy. 😄 