### PR TITLE
Expose default/name param to prompt

### DIFF
--- a/lib/params.js
+++ b/lib/params.js
@@ -48,7 +48,7 @@ function () {
           subaction = _L$split2[1];
 
     const actionfolder = path.join(templates, generator, mainAction);
-    const promptArgs = yield prompt(createPrompter, actionfolder, L.omit(argv, ['_']));
+    const promptArgs = yield prompt(createPrompter, actionfolder, {name, ...L.omit(argv, ['_'])});
     const args = Object.assign({
       templates,
       actionfolder,


### PR DESCRIPTION
Pass to prompt default name param. 
That way we are able to validate/access "default" name param (param without --name) on the prompt flow.