### PR TITLE
Allow debug to be driven by the resolvedConfig

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ const runner = async (
     return { success: true, actions, time: 0 }
   } catch (err) {
     logger.log(err.toString())
-    if (config.debug) {
+    if (resolvedConfig.debug) {
       logger.log('details -----------')
       logger.log(err.stack)
       logger.log('-------------------')


### PR DESCRIPTION
My team enjoys seeing stack traces by default in our cli tools, especially when they point back to our prompt code. 

This change would allow us to set debug via `.hygen.js`