### PR TITLE
docs(help): add change-case help text

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1,6 +1,8 @@
 import fs from 'fs-extra'
 import { ActionResult, RunnerConfig } from './types'
 import params from './params'
+import { mainHelp } from './help/main-help'
+import { templatesHelp } from './help/templates-help';
 
 const engine = async (
   argv: string[],
@@ -11,13 +13,12 @@ const engine = async (
   const { generator, action, actionfolder } = args
 
   if (['-h', '--help'].includes(argv[0])) {
-    logger.log(`
-Usage:
-  hygen [option] GENERATOR ACTION [--name NAME] [data-options]
+    logger.log(mainHelp());
+    process.exit(0)
+  }
 
-Options:
-  -h, --help # Show this message and quit
-  --dry      # Perform a dry run.  Files will be generated but not saved.`)
+  if (['--help-templates'].includes(argv[0])) {
+    logger.log(templatesHelp());
     process.exit(0)
   }
 

--- a/src/help/change-case-help.ts
+++ b/src/help/change-case-help.ts
@@ -1,0 +1,130 @@
+export function changeCaseHelp() {
+  return `change-case - https://github.com/blakeembrey/change-case
+
+    camelCase
+
+      Return as a string with the separators denoted by having the next letter capitalized.
+    
+      changeCase.camelCase('test string')
+      //=> "testString"
+
+    constantCase
+
+      Return as an upper case, underscore separated string.
+
+      changeCase.constantCase('test string')
+      //=> "TEST_STRING"
+      
+    dotCase
+
+      Return as a lower case, period separated string.
+
+      changeCase.dotCase('test string')
+      //=> "test.string"
+
+    headerCase
+
+      Return as a title cased, dash separated string.
+
+      changeCase.headerCase('test string')
+      //=> "Test-String"
+
+    isLowerCase
+
+      Return a boolean indicating whether the string is lower cased.
+
+      changeCase.isLowerCase('test string')
+      //=> true
+
+    isUpperCase
+
+      Return a boolean indicating whether the string is upper cased.
+
+      changeCase.isUpperCase('test string')
+      //=> false
+
+    lowerCase
+
+      Return the string in lower case.
+
+      changeCase.lowerCase('TEST STRING')
+      //=> "test string"
+
+    lowerCaseFirst
+
+      Return the string with the first character lower cased.
+
+      changeCase.lowerCaseFirst('TEST')
+      //=> "tEST"
+
+    noCase
+
+      Return the string without any casing (lower case, space separated).
+
+      changeCase.noCase('test string')
+      //=> "test string"
+
+    paramCase (kebabCase, hyphenCase)
+
+      Return as a lower case, dash separated string.
+
+      changeCase.paramCase('test string')
+      //=> "test-string"
+
+    pascalCase
+
+      Return as a string denoted in the same fashion as 'camelCase', but with the first letter also capitalized.
+
+      changeCase.pascalCase('test string')
+      //=> "TestString"
+
+    pathCase
+
+      Return as a lower case, slash separated string.
+
+      changeCase.pathCase('test string')
+      //=> "test/string"
+
+    sentenceCase
+
+      Return as a lower case, space separated string with the first letter upper case.
+
+      changeCase.sentenceCase('testString')
+      //=> "Test string"
+
+    snakeCase
+
+      Return as a lower case, underscore separated string.
+
+      changeCase.snakeCase('test string')
+      //=> "test_string"
+
+    swapCase
+
+      Return as a string with every character case reversed.
+
+      changeCase.swapCase('Test String')
+      //=> "tEST sTRING"
+
+    titleCase
+
+      Return as a space separated string with the first character of every word upper cased.
+
+      changeCase.titleCase('a simple test')
+      //=> "A Simple Test"
+
+    upperCase
+
+      Return the string in upper case.
+
+      changeCase.upperCase('test string')
+      //=> "TEST STRING"
+
+    upperCaseFirst
+
+      Return the string with the first character upper cased.
+
+      changeCase.upperCaseFirst('test')
+      //=> "Test"
+  `
+}

--- a/src/help/change-case-help.ts
+++ b/src/help/change-case-help.ts
@@ -1,5 +1,5 @@
 export function changeCaseHelp() {
-  return `change-case - https://github.com/blakeembrey/change-case
+  return `# change-case - https://github.com/blakeembrey/change-case
 
     camelCase
 

--- a/src/help/inflection-help.ts
+++ b/src/help/inflection-help.ts
@@ -1,0 +1,123 @@
+export function inflectionHelp() {
+  return `inflection - https://github.com/dreamerslab/node.inflection
+
+    indexOf
+    
+      This lets us detect if an Array contains a given element.
+
+      inflection.indexOf([ 'hi','there' ], 'guys' ); // === -1
+      inflection.indexOf([ 'hi','there' ], 'hi' ); // === 0
+
+    pluralize
+
+      This function adds pluralization support to every String object.
+
+      inflection.pluralize( 'person' ); // === 'people'
+      inflection.pluralize( 'octopus' ); // === "octopi"
+      inflection.pluralize( 'Hat' ); // === 'Hats'
+      inflection.pluralize( 'person', 'guys' ); // === 'guys'
+
+    singularize
+
+      This function adds singularization support to every String object.
+
+      inflection.singularize( 'people' ); // === 'person'
+      inflection.singularize( 'octopi' ); // === "octopus"
+      inflection.singularize( 'Hats' ); // === 'Hat'
+      inflection.singularize( 'guys', 'person' ); // === 'person'
+
+    inflect
+
+      This function will pluralize or singularlize a String appropriately based on an integer value.
+
+      inflection.inflect( 'people', 1 ); // === 'person'
+      inflection.inflect( 'octopi', 1 ); // === 'octopus'
+      inflection.inflect( 'Hats', 1 ); // === 'Hat'
+      inflection.inflect( 'guys', 1 , 'person' ); // === 'person'
+      inflection.inflect( 'person', 2 ); // === 'people'
+      inflection.inflect( 'octopus', 2 ); // === 'octopi'
+      inflection.inflect( 'Hat', 2 ); // === 'Hats'
+      inflection.inflect( 'person', 2, null, 'guys' ); // === 'guys'
+
+    camelize
+
+      This function transforms String object from underscore to camelcase.
+
+      inflection.camelize( 'message_properties' ); // === 'MessageProperties'
+      inflection.camelize( 'message_properties', true ); // === 'messageProperties'
+
+    underscore
+
+      This function transforms String object from camelcase to underscore.
+
+      inflection.underscore( 'MessageProperties' ); // === 'message_properties'
+      inflection.underscore( 'messageProperties' ); // === 'message_properties'
+      inflection.underscore( 'MP' ); // === 'm_p'
+      inflection.underscore( 'MP', true ); // === 'MP'
+
+    humanize
+
+      This function adds humanize support to every String object.
+
+      inflection.humanize( 'message_properties' ); // === 'Message properties'
+      inflection.humanize( 'message_properties', true ); // === 'message properties'
+
+    capitalize
+
+      This function adds capitalization support to every String object.
+
+      inflection.capitalize( 'message_properties' ); // === 'Message_properties'
+      inflection.capitalize( 'message properties', true ); // === 'Message properties'
+
+    dasherize
+
+      This function replaces underscores with dashes in the string.
+
+      inflection.dasherize( 'message_properties' ); // === 'message-properties'
+      inflection.dasherize( 'Message Properties' ); // === 'Message-Properties'
+
+    titleize
+
+      This function adds titleize support to every String object.
+
+      inflection.titleize( 'message_properties' ); // === 'Message Properties'
+      inflection.titleize( 'message properties to keep' ); // === 'Message Properties to Keep'
+
+    demodulize
+
+      This function adds demodulize support to every String object.
+
+      inflection.demodulize( 'Message::Bus::Properties' ); // === 'Properties'
+
+    tableize
+
+      This function adds tableize support to every String object.
+
+      inflection.tableize( 'MessageBusProperty' ); // === 'message_bus_properties'
+
+    classify
+
+      This function adds classification support to every String object.
+
+      inflection.classify( 'message_bus_properties' ); // === 'MessageBusProperty'
+
+    foreign_key
+
+      This function adds foreign key support to every String object.
+
+      inflection.foreign_key( 'MessageBusProperty' ); // === 'message_bus_property_id'
+      inflection.foreign_key( 'MessageBusProperty', true ); // === 'message_bus_propertyid'
+
+    ordinalize
+
+      This function adds ordinalize support to every String object.
+
+      inflection.ordinalize( 'the 1 pitch' ); // === 'the 1st pitch'
+
+    transform
+
+      This function performs multiple inflection methods on a string.
+
+      inflection.transform( 'all job', [ 'pluralize', 'capitalize', 'dasherize' ]); // === 'All-jobs'
+  `
+}

--- a/src/help/inflection-help.ts
+++ b/src/help/inflection-help.ts
@@ -1,5 +1,5 @@
 export function inflectionHelp() {
-  return `inflection - https://github.com/dreamerslab/node.inflection
+  return `# inflection - https://github.com/dreamerslab/node.inflection
 
     indexOf
     

--- a/src/help/main-help.ts
+++ b/src/help/main-help.ts
@@ -1,0 +1,16 @@
+/**
+ * Get help text
+ *
+ * @returns {string} help text
+ */
+export function mainHelp() {
+  return `
+Usage:
+  hygen [option] GENERATOR ACTION [--name NAME] [data-options]
+
+Options:
+  -h, --help         # Show this message and quit
+  --help-templates   # Show help regarding template helpers
+  --dry              # Perform a dry run.  Files will be generated but not saved.
+`
+}

--- a/src/help/templates-help.ts
+++ b/src/help/templates-help.ts
@@ -1,0 +1,16 @@
+import { changeCaseHelp } from './change-case-help'
+import { inflectionHelp } from './inflection-help'
+
+export function templatesHelp() {
+  return `
+Template Helpers:
+  You can use several provided helpers to transform and check text inside templates. 
+
+    // example: <%= h.changeCase.camel(name) %>
+    // example: <%= h.inflection.pluralize(name) %>
+
+  ${changeCaseHelp()}
+
+  ${inflectionHelp()}
+  `
+}

--- a/src/help/templates-help.ts
+++ b/src/help/templates-help.ts
@@ -9,6 +9,69 @@ Template Helpers:
     // example: <%= h.changeCase.camel(name) %>
     // example: <%= h.inflection.pluralize(name) %>
 
+  # Methods summary - Change Case
+
+  changeCase.camelCase('test string')    // => "testString"
+  changeCase.constantCase('test string') // => "TEST_STRING"
+  changeCase.dotCase('test string')      // => "test.string"
+  changeCase.headerCase('test string')   // => "Test-String"
+  changeCase.isLowerCase('test string')  // => true
+  changeCase.isUpperCase('test string')  // => false
+  changeCase.lowerCase('TEST STRING')    // => "test string"
+  changeCase.lowerCaseFirst('TEST')      // => "tEST"
+  changeCase.noCase('test string')       // => "test string"
+  changeCase.paramCase('test string')    // => "test-string"
+  changeCase.pascalCase('test string')   // => "TestString"
+  changeCase.pathCase('test string')     // => "test/string"
+  changeCase.sentenceCase('testString')  // => "Test string"
+  changeCase.snakeCase('test string')    // => "test_string"
+  changeCase.swapCase('Test String')     // => "tEST sTRING"
+  changeCase.titleCase('a simple test')  // => "A Simple Test"
+  changeCase.upperCase('test string')    // => "TEST STRING"
+  changeCase.upperCaseFirst('test')      // => "Test"
+
+  # Methods summary - Inflection
+
+  inflection.indexOf([ 'hi','there' ], 'guys' );       // === -1
+  inflection.indexOf([ 'hi','there' ], 'hi' );         // === 0
+  inflection.pluralize( 'person' );                    // === 'people'
+  inflection.pluralize( 'octopus' );                   // === "octopi"
+  inflection.pluralize( 'Hat' );                       // === 'Hats'
+  inflection.pluralize( 'person', 'guys' );            // === 'guys'
+  inflection.singularize( 'people' );                  // === 'person'
+  inflection.singularize( 'octopi' );                  // === "octopus"
+  inflection.singularize( 'Hats' );                    // === 'Hat'
+  inflection.singularize( 'guys', 'person' );          // === 'person'
+  inflection.inflect( 'people', 1 );                   // === 'person'
+  inflection.inflect( 'octopi', 1 );                   // === 'octopus'
+  inflection.inflect( 'Hats', 1 );                     // === 'Hat'
+  inflection.inflect( 'guys', 1 , 'person' );          // === 'person'
+  inflection.inflect( 'person', 2 );                   // === 'people'
+  inflection.inflect( 'octopus', 2 );                  // === 'octopi'
+  inflection.inflect( 'Hat', 2 );                      // === 'Hats'
+  inflection.inflect( 'person', 2, null, 'guys' );     // === 'guys'
+  inflection.camelize( 'message_properties' );         // === 'MessageProperties'
+  inflection.camelize( 'message_properties', true );   // === 'messageProperties'
+  inflection.underscore( 'MessageProperties' );        // === 'message_properties'
+  inflection.underscore( 'messageProperties' );        // === 'message_properties'
+  inflection.underscore( 'MP' );                       // === 'm_p'
+  inflection.underscore( 'MP', true );                 // === 'MP'
+  inflection.humanize( 'message_properties' );         // === 'Message properties'
+  inflection.humanize( 'message_properties', true );   // === 'message properties'
+  inflection.capitalize( 'message_properties' );       // === 'Message_properties'
+  inflection.capitalize( 'message properties', true ); // === 'Message properties'
+  inflection.dasherize( 'message_properties' );        // === 'message-properties'
+  inflection.dasherize( 'Message Properties' );        // === 'Message-Properties'
+  inflection.titleize( 'message_properties' );         // === 'Message Properties'
+  inflection.titleize( 'message properties to keep' ); // === 'Message Properties to Keep'
+  inflection.demodulize( 'Message::Bus::Properties' ); // === 'Properties'
+  inflection.tableize( 'MessageBusProperty' );         // === 'message_bus_properties'
+  inflection.classify( 'message_bus_properties' );     // === 'MessageBusProperty'
+  inflection.foreign_key( 'MessageBusProperty' );      // === 'message_bus_property_id'
+  inflection.foreign_key( 'MessageBusProperty', true );// === 'message_bus_propertyid'
+  inflection.ordinalize( 'the 1 pitch' );              // === 'the 1st pitch'
+  inflection.transform( 'all job', [ 'pluralize', 'capitalize', 'dasherize' ]); // === 'All-jobs'
+
   ${changeCaseHelp()}
 
   ${inflectionHelp()}


### PR DESCRIPTION
Belongs to issue #169 .

Add help text for template helpers - changeCase and inflection.

1. I've added a new cli option `help-templates` because the template help was overcrowding the main help. I thought separating them would be more appropriate.

2. The text is in bare format. Markdown maybe for usefull in this case. https://github.com/axiros/terminal_markdown_viewer

3. The text is taken from the readme of those repositories. Maybe a more condence oneline per command example+result would be more appropriate.

I could take a look at `2` or `3` if those options are more wanted but it will take more time or could be done in another PR.