### PR TITLE
[chore] Move ts-jest to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "fs-extra": "^7.0.1",
     "ignore-walk": "^3.0.2",
     "inflection": "^1.12.0",
-    "ts-jest": "^24.1.0",
     "yargs-parser": "^13.0.0"
   },
   "devDependencies": {
@@ -48,6 +47,7 @@
     "jest": "^24.3.1",
     "pkg": "^4.4.0",
     "time-require": "^0.1.2",
+    "ts-jest": "^24.1.0",
     "ts-node": "^8.4.1",
     "typescript": "^3.6.4",
     "zeroconf-typescript-eslint": "^2.0.0"


### PR DESCRIPTION
Having `ts-jest` in `"dependencies"` includes it in the published version of this package. As far as I can tell, this package is only using `ts-jest` for tests. So this PR moves it to `devDependencies`.

We use Hygen at Airbnb, and this is blocking us from updating jest to v25.1.0 due to an unmet peer dependency from this package. 

```
Airbnb@1.0.0 /Users/sharmila_jesupaul/airlab/repos/airbnb-1
├─┬ hygen@5.0.1
│ └── ts-jest@24.3.0
└── ts-jest@25.2.0

npm ERR! peer dep missing: jest@>=24 <25, required by ts-jest@24.3.0
```

@jondot 