### PR TITLE
feat: add locals defaults to config

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.19",
+    "@types/node": "^13.13.0",
     "conventional-changelog-cli": "^2.0.11",
     "dir-compare": "^1.4.0",
     "gh-pages": "^1.1.0",

--- a/src/__tests__/render.spec.ts
+++ b/src/__tests__/render.spec.ts
@@ -157,4 +157,25 @@ describe('render ng', () => {
     expect(actualFile).toMatch(expectedFile)
     expect(actualBody).toMatch(expectedBody)
   })
+
+  it('should use config.localsDefaults for not passed parameters', async () => {
+    // setup
+    const expectedFile = /full/
+    const expectedBody = /localsDefaultBill/
+    const config = {
+      localsDefaults: {
+        name: 'localsDefaultFileName',
+        bill: 'localsDefaultBill',
+      },
+    }
+    // act
+    const response = await render({
+      actionfolder: fixture('app/action-full'),
+    }, config)
+    const actualFile = response[0].file
+    const actualBody = response[0].body
+    // assert
+    expect(actualFile).toMatch(expectedFile)
+    expect(actualBody).toMatch(expectedBody)
+  })
 })

--- a/src/context.ts
+++ b/src/context.ts
@@ -30,8 +30,8 @@ const localsDefaults = {
 
 const capitalizedLocals = (locals: any) => Object.entries(locals).reduce(doCapitalization, {});
 
-const context = (locals: any, config: RunnerConfig) => {
-  const localsWithDefaults = Object.assign({}, localsDefaults, locals);
+const context = (locals: any, config: RunnerConfig = {}) => {
+  const localsWithDefaults = Object.assign({}, localsDefaults, config.localsDefaults, locals);
   const configHelpers = config && (typeof config.helpers === "function" ? config.helpers(locals, config) : config.helpers) || {};
   return Object.assign(localsWithDefaults, capitalizedLocals(localsWithDefaults), {
     h: { ...helpers, ...configHelpers }

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,7 @@ export interface RunnerConfig {
   logger?: Logger
   debug?: boolean
   helpers?: any
+  localsDefaults?: any
   createPrompter?: <Q, T>() => Prompter<Q, T>
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -455,6 +455,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-11.11.0.tgz#070e9ce7c90e727aca0e0c14e470f9a93ffe9390"
   integrity sha512-D5Rt+HXgEywr3RQJcGlZUCTCx1qVbCZpVk3/tOOA6spLNZdGm8BU+zRgdRYDoF1pO3RuXLxADzMrF903JlQXqg==
 
+"@types/node@^13.13.0":
+  version "13.13.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.0.tgz#30d2d09f623fe32cde9cb582c7a6eda2788ce4a8"
+  integrity sha512-WE4IOAC6r/yBZss1oQGM5zs2D7RuKR6Q+w+X2SouPofnWn+LbCqClRyhO3ZE7Ix8nmFgo/oVuuE01cJT2XB13A==
+
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"


### PR DESCRIPTION
It would be really useful to be able to define default values for parameters (locals) in the config file: **.hygen.js**

Right now only way to pass default parameters is by defining them as helpers:
`module.exports = {
  helpers: { defaults: { name: "default" } }
}`

And in template use them as:
`<%= name || h.defaults.name %>`
