### PR TITLE
Ability to output abs path of generated files to terminal (useful for lerna, etc.)

### DIFF
--- a/src/ops/add.ts
+++ b/src/ops/add.ts
@@ -43,7 +43,8 @@ const add = async (
     await fs.ensureDir(path.dirname(absTo))
     await fs.writeFile(absTo, action.body)
   }
-  logger.ok(`       added: ${to}`)
+  const pathToLog = process.env.HYGEN_OUTPUT_ABS_PATH ? absTo : to
+  logger.ok(`       added: ${pathToLog}`)
   return result('added')
 }
 

--- a/src/ops/inject.ts
+++ b/src/ops/inject.ts
@@ -34,7 +34,8 @@ const injectOp = async (
   if (!args.dry) {
     await fs.writeFile(absTo, injectResult)
   }
-  logger.notice(`      inject: ${to}`)
+  const pathToLog = process.env.HYGEN_OUTPUT_ABS_PATH ? absTo : to
+  logger.notice(`      inject: ${pathToLog}`)
 
   return result('inject')
 }


### PR DESCRIPTION
Using Hygen with Lerna in a multi package repo works great except for one small problem.

When executing a sub package script that uses Hygen from the root folder (via lerna run). The filename that is outputted to the terminal is relative to the sub-package. This means code editors like VS code that enable quick linking to files do not work.

* Add environment variable HYGEN_OUTPUT_ABS_PATH. 
* This variable is used to determine whether to display absolute or relative file paths when outputting generated filenames to the terminal