### PR TITLE
Exit hygen on shell command error

### DIFF
--- a/src/ops/shell.ts
+++ b/src/ops/shell.ts
@@ -10,7 +10,11 @@ const shell = async (
   const result = createResult('shell', sh)
   if (notEmpty(sh)) {
     if (!args.dry) {
-      await exec(sh, body)
+      try {
+        await exec(sh, body)
+      } catch (error) {
+        process.exit(1)
+      }
     }
     logger.ok(`       shell: ${sh}`)
 


### PR DESCRIPTION
This will allow to chain hygen commands and have them exit on error.
E.g.
hygen generate test && hygen make cake
If the first fails, the second will not run.