### PR TITLE
fix(deps): fix chalk template path

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -7,7 +7,7 @@ const yellow = chalk.yellow,
       green = chalk.green,
       magenta = chalk.magenta;
 
-const template = require('chalk/templates');
+const template = require('chalk/source/templates');
 
 class Logger {
   constructor(log) {


### PR DESCRIPTION
Seems there was a breaking change in the chalk dependency which moved/renamed the [templates file here](https://github.com/chalk/chalk/commit/655653bb0c88fb05f839d5027f79751449771ec4#diff-3aa187c5a65150da43420c7f80d874cc)

This fixes it so it matches the updated path