### PR TITLE
Fix #288 issue 

### DIFF
--- a/src/ops/injector.ts
+++ b/src/ops/injector.ts
@@ -62,7 +62,7 @@ const injector = (action: RenderedAction, content: string): string => {
     }
   }
 
-  return lines.join('\n')
+  return lines.join(EOL)
 }
 
 export default injector


### PR DESCRIPTION
At the moment, when hygen injects a file, it saves it with a Linux end of line (LF, \n). The next time that hygen will try to re-inject this file, it will split the content with the windows end of line (CRLF, \r\n) so it will fail to find the right line! 