### PR TITLE
Fix documentation colours for dark mode

### DIFF
--- a/hygen.io/src/css/custom.css
+++ b/hygen.io/src/css/custom.css
@@ -29,7 +29,6 @@ h6{
 .navbar {
   backdrop-filter: saturate(180%) blur(5px);
   -webkit-backdrop-filter: saturate(180%) blur(5px);
-  background-color: rgba(255,255,255,0.8);
 }
 
 .docusaurus-highlight-code-line {

--- a/hygen.io/src/pages/index.js
+++ b/hygen.io/src/pages/index.js
@@ -155,8 +155,8 @@ const Hero = styled.div`
     margin-top: 15px;
   }
 `
+
 const Subtitle = styled.h2`
-  color: #000;
   font-weight: 600;
   margin: 1.2rem 0;
   letter-spacing: -1px;
@@ -188,7 +188,6 @@ const Feature = styled.div`
   padding: 1rem;
 `
 const IndexHeadContainer = styled.div`
-  background: white;
   padding: 20px;
   text-align: center;
   border-bottom: 1px solid #f0f0f0;


### PR DESCRIPTION
Hey, thanks for the cool library!

I've just started using it and I found some minor colours issues in the documentation and I would like to contribute fixing it.

Before:

![image](https://user-images.githubusercontent.com/1657840/116817469-cb414b80-ab66-11eb-8601-d3c9126b9c69.png)

Now:

![image](https://user-images.githubusercontent.com/1657840/116817481-de541b80-ab66-11eb-9433-1a8308a2d0d7.png)

Before:

![image](https://user-images.githubusercontent.com/1657840/116817499-f166eb80-ab66-11eb-8230-b671074aac3f.png)

Now:

![image](https://user-images.githubusercontent.com/1657840/116817506-ffb50780-ab66-11eb-9f4b-7e8ce11e24a4.png)

