### PR TITLE
PR #248 missed this Chalk reference in its fix

### DIFF
--- a/dist/logger.js
+++ b/dist/logger.js
@@ -1,7 +1,8 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 const chalk = require('chalk');
-const { yellow, red, green, magenta, template } = chalk;
+const { yellow, red, green, magenta } = chalk;
+const template = require('chalk/source/templates');
 class Logger {
     constructor(log) {
         this.log = log;


### PR DESCRIPTION
https://github.com/jondot/hygen/pull/248 fixed a change in Chalk that meant `template` wasn't resolving, but this second copy of the same file was missed, which leads to the command-line help, for example: `hygen generator help`, to not properly render chalk sequences.