### PR TITLE
Allow access to runner configuration in advanced prompts

### DIFF
--- a/src/params.ts
+++ b/src/params.ts
@@ -4,9 +4,10 @@ import { RunnerConfig, ParamsResult } from './types'
 import prompt from './prompt'
 
 const params = async (
-  { templates, createPrompter }: RunnerConfig,
+  config: RunnerConfig,
   externalArgv: string[],
 ): Promise<ParamsResult> => {
+  const { templates, createPrompter } = config
   const argv = yargs(externalArgv)
 
   const [generator, action, name] = argv._
@@ -23,7 +24,7 @@ const params = async (
     // but theres no usecase yet
     ...(name ? { name } : {}),
     ...cleanArgv,
-  })
+  }, config)
 
   const args = Object.assign(
     {

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -1,12 +1,13 @@
 import path from 'path'
 import fs from 'fs'
-import { Prompter } from './types'
+import { Prompter, RunnerConfig } from './types'
 
 const hooksfiles = ['prompt.js', 'index.js']
 const prompt = <Q, T>(
   createPrompter: () => Prompter<Q, T>,
   actionfolder: string,
   args: Record<string, any>,
+  config: RunnerConfig,
 ): Promise<T | object> => {
   const hooksfile = hooksfiles
     .map(f => path.resolve(path.join(actionfolder, f)))
@@ -20,14 +21,14 @@ const prompt = <Q, T>(
   // $FlowFixMe
   const hooksModule = require(hooksfile)
   if (hooksModule.params) {
-    return hooksModule.params({ args })
+    return hooksModule.params({ args, config })
   }
 
   // lazy loads prompter
   // everything below requires it
   const prompter = createPrompter()
   if (hooksModule.prompt) {
-    return hooksModule.prompt({ prompter, inquirer: prompter, args })
+    return hooksModule.prompt({ prompter, inquirer: prompter, args, config })
   }
 
   return prompter.prompt(


### PR DESCRIPTION
I am migrating from Yeoman to Hygen for the https://github.com/feathersjs/feathers CLI which is working great so far, one small thing I needed a couple of times was access to the runner configuration (specifically the helpers I am passing) in the [advanced interactive prompt](http://www.hygen.io/docs/generators#advanced-interactive-prompt) scenario. My suggestion would be to pass it along to the `.prompt` function.