### PR TITLE
add debug logging during render

### DIFF
--- a/src/render.ts
+++ b/src/render.ts
@@ -54,7 +54,10 @@ const render = async (
     )
     .then(_ => Promise.all(_))
     .then(
-      map(({ file, text }) => ({ file, ...fm(text, { allowUnsafe: true }) })),
+      map(({ file, text }) => {
+          if(config.debug) console.debug('Pre-formatting file:', file)
+          return { file, ...fm(text, { allowUnsafe: true }) }
+      }),
     )
     .then(
       map(({ file, attributes, body }) => {
@@ -67,6 +70,7 @@ const render = async (
           },
           {},
         )
+        if(config.debug) console.debug('Rendering file:', file)
         return {
           file,
           attributes: renderedAttrs,


### PR DESCRIPTION
I recently experienced an error like: 
YAMLException: unexpected end of the stream within a double quoted scalar at line 2, column 1:

    ^

I had to debug the render.js script to figure out which file was having an issue, having this would have made it much easier to figure out what was wrong.