### PR TITLE
skip_if 'flag' added to ops/add attributes

### DIFF
--- a/src/__tests__/__snapshots__/add.spec.ts.snap
+++ b/src/__tests__/__snapshots__/add.spec.ts.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`add should return "skipped" if skip_if has value  1`] = `
+Object {
+  "status": "ignored",
+  "subject": undefined,
+  "timing": Any<Number>,
+  "type": "add",
+}
+`;

--- a/src/__tests__/add.spec.ts
+++ b/src/__tests__/add.spec.ts
@@ -1,0 +1,32 @@
+import add from '../ops/add'
+import Logger from '../logger'
+
+// const gemfile = `
+//     source 'http://rubygems.org'
+//     gem 'rails'
+//     gem 'nokogiri'
+//     gem 'httparty'
+//     `
+
+// TODO and inject is false
+describe('add', () => {
+  it('should return "skipped" if skip_if has value ', async () => {
+    expect(
+      await add(
+        {
+          attributes: {
+            skip_if: 'true',
+          },
+          body: 'this should be skipped',
+        },
+        {},
+        {
+          logger: new Logger(console.log),
+          debug: false,
+          helpers: {},
+          createPrompter: () => require('enquirer'),
+        },
+      ),
+    ).toMatchSnapshot({ timing: expect.any(Number) })
+  })
+})

--- a/src/ops/add.ts
+++ b/src/ops/add.ts
@@ -43,7 +43,7 @@ const add = async (
     }
   }
 
-  const shouldSkip = !!skip_if;
+  const shouldSkip = skip_if === 'true'
   if(shouldSkip) {
     return result('skipped')
   }

--- a/src/ops/add.ts
+++ b/src/ops/add.ts
@@ -11,7 +11,7 @@ const add = async (
   { logger, cwd, createPrompter }: RunnerConfig,
 ): Promise<ActionResult> => {
   const {
-    attributes: { to, inject, unless_exists, force, from },
+    attributes: { to, inject, unless_exists, force, from, skip_if },
   } = action
   const result = createResult('add', to)
   const prompter = createPrompter()
@@ -43,6 +43,10 @@ const add = async (
     }
   }
 
+  const shouldSkip = !!skip_if;
+  if(shouldSkip) {
+    return result('skipped')
+  }
 
   if (from) {
     const from_path = path.join(args.templates, from)


### PR DESCRIPTION
Seeing as `skip_if` exists for the `ops/inject`, I've added a conditional for the `ops/add`.

With these changes a developer could do the following:

`prompt.js`
```
'use strict'

module.exports = {
  prompt: ({ prompter, args }) => {
    return prompter.prompt([
      {
        type: 'MultiSelect',
        name: 'files',
        message: 'Files:',
        initial: ['Controller', 'Service'],
        choices: [
          {
            name: 'Controller',
            value: 'controller',
          },
          {
            name: 'Service',
            value: 'template',
          }
        ],
      }
    ])
  }
}
```

And then in the template:
`controller.ejs.t`
```
---
to: "src/modules/<%= h.fileName(name) %>/<%= h.controllerFileName(name) %>.ts"
unless_exists: true
skip_if: <%= !files.includes('Controller') %>
---
```


Closes #362 