### PR TITLE
Add echo: command -> ops

### DIFF
--- a/src/ops/echo.ts
+++ b/src/ops/echo.ts
@@ -1,0 +1,18 @@
+import { ActionResult } from '../types'
+import createResult from './result'
+
+const notEmpty = x => x && x.length > 0
+const echo = async (
+  { attributes: { echo }},
+  _args:any,
+  { logger },
+): Promise<ActionResult> => {
+  const result = createResult('shell', echo)
+  if (notEmpty(echo)) {
+    logger.colorful(echo)
+    return result('executed')
+  }
+  return result('ignored')
+}
+
+export default echo

--- a/src/ops/index.ts
+++ b/src/ops/index.ts
@@ -8,6 +8,10 @@ const resolve = attributes => {
     const inject = require('./inject').default
     ops.push(inject)
   }
+  if (attributes.echo) {
+    const echo = require('./echo').default
+    ops.push(echo)
+  }
   if (attributes.sh) {
     const shell = require('./shell').default
     ops.push(shell)


### PR DESCRIPTION
Adding an echo command which can be used instead of `sh: echo "blabla"`
`echo:` runs before any shell command, in case you want to notify the user of a longer running operation.


```yaml
---
echo: This is a test of {inverse inverse}. It should run before the shell command is executed
sh: do some long operation like npm install
message: This shows when the shell command is finished
---

```

Also suppots multiline
```yaml
---
echo: |
  some multiline
  comment
  which renders
  as multiple lines
---
```