### PR TITLE
fix(docs): change [[info]] blocks with correct syntax

### DIFF
--- a/hygen.io/docs/generators.md
+++ b/hygen.io/docs/generators.md
@@ -52,11 +52,14 @@ $ cp _templates/mailer/new/{html.ejs.t,text.ejs.t}
 
 We use a `.t` suffix because it disables our editor trying to be smart - use what ever you like. For this example these files represent the HTML and text forms of an email sender.
 
-[[info]]
+:::info
 | ###### Creative Freedom
 | hygen doesn't care about file names or file types in your generator folders. It only cares about folder structure and the _contents_ of your files.
 
 Also note that each template has a _frontmatter_ delimited by a pair of `---`'s. In our example, we have a special `to:` property which tells `hygen` where to put the generated file. We'll see more of these in [templates](/docs/templates).
+:::
+
+<br />
 
 ## Structure
 
@@ -77,12 +80,15 @@ Every time you call it, `hygen mailer new` automagically picks up the closest `_
 
 As of [PR 102](https://github.com/jondot/hygen/pull/102) Hygen will recursively walk your template folder, so that you can structure your generators as elaborately as you wish.
 
-[[info]]
+:::info
 |###### Hygen is Contextual
 |`hygen` simplifies things by asserting "command structure is folder structure".
 |
 |
 |`hygen` will pick up the `_templates` in your current working directory.
+:::
+
+<br />
 
 ## CLI Arguments
 
@@ -220,9 +226,13 @@ module.exports = {
 }
 ```
 
-[[info]]
+:::info
 | ###### Params and Prompts are The Same
 | If you think about it, prompting for variables or reshaping CLI arguments lead to the same goal: new parameters. But to make a future-proof API, we've separated the two intents to the `prompt` and `params` functions.
+:::
+
+<br />
+
 
 ## Documenting Your Generators
 

--- a/hygen.io/docs/quick-start.md
+++ b/hygen.io/docs/quick-start.md
@@ -37,8 +37,10 @@ $ hygen mailer new [NAME]
          `------------ generator
 ```
 
-[[info]]
-| New in hygen 4.0.0: a positional `NAME` parameter to save a bit of typing. With versions prior to 4.0.0 you still have to use `--name NAME`.
+:::info
+New in hygen 4.0.0: a positional `NAME` parameter to save a bit of typing. With versions prior to 4.0.0 you still have to use `--name NAME`.
+:::
+
 
 Here's a quick run-down to get to your own generator:
 
@@ -65,8 +67,11 @@ Congratz! you've made a new generator called `awesome-generator`!
 
 Let's walk through what we just did.
 
-[[info]]
+:::info
 | You can also install `hygen` from Homebrew or download a standalone binary. For more, see [standalone](/docs/standalone).
+:::
+
+<br />
 
 ## Bootstrapping Your Project
 
@@ -87,9 +92,11 @@ This creates a project-local `_templates` folder for you at your source root wit
 * `hygen generator new generatorName` - builds a new generator for you
 * `hygen generator with-prompt new generatorName` - the same as before, only this one will be prompt driven.
 
-[[info]]
-|###### Template Locality
-|On multi-team projects, each team can have their own templates right there in the shared repo.
+:::info
+###### Template Locality
+On multi-team projects, each team can have their own templates right there in the shared repo.
+:::
+
 
 Still in your project root, let's create a new generator now:
 
@@ -108,12 +115,13 @@ Loaded templates: _templates
        added: app/hello.js
 ```
 
-[[info]]
-|###### Did You Notice?
-|Instead of bundling the `hygen generator new` command in `hygen`, we chose to _copy_ it to your local templates folder.
-|
-|
-|In this way you can even tweak the way `hygen` generates new generators. It scales to a set up with different teams, each with its own preference.
+:::info
+###### Did You Notice?
+Instead of bundling the `hygen generator new` command in `hygen`, we chose to _copy_ it to your local templates folder.
+
+In this way you can even tweak the way `hygen` generates new generators. It scales to a set up with different teams, each with its own preference.
+:::
+
 
 That's it! we've done a basic walkthrough of `hygen`. Next up is a detailed overview of [templates](/docs/templates) and [generators](/docs/generators).
 

--- a/hygen.io/docs/templates.md
+++ b/hygen.io/docs/templates.md
@@ -43,11 +43,13 @@ foo: ping
 ---
 ```
 
-[[info]]
-|###### Frontmatter cleans up our act
-|While other generator engines use the file names, folder structure, or arbitrary configuration files to store metadata, `hygen` uses the frontmatter.
-|
-|This makes templating and generators clean and maintainable and meta data lives directly in the template it refers to.
+:::info
+###### Frontmatter cleans up our act
+While other generator engines use the file names, folder structure, or arbitrary configuration files to store metadata, `hygen` uses the frontmatter.
+
+This makes templating and generators clean and maintainable and meta data lives directly in the template it refers to.
+:::
+
 
 ## Template Body
 
@@ -276,9 +278,10 @@ skip_if: react-native-fs
 
 The new props to notice here are `after` and `skip_if`. This template will add the `react-native-fs` dependency into a `package.json` file, but it will not add it twice (because of `skip_if`).
 
-[[info]]
-|###### Regular expressions everywhere promote flexibility
-| In `after: dependencies`, 'dependencies' is actually a regular expression, so it'll find the `"dependencies":{` block in a `package.json` file
+:::info
+###### Regular expressions everywhere promote flexibility
+In `after: dependencies`, 'dependencies' is actually a regular expression, so it'll find the `"dependencies":{` block in a `package.json` file
+:::
 
 Here are the available properties for an `inject: true` template:
 


### PR DESCRIPTION
I changed the `[[info]]` blocks with the recommended syntax according to [docusaurus docs](https://docusaurus.io/fr/docs/next/markdown-features/admonitions).

I hope that was the intent. However, the color theme makes `INFO` blocks too shiny 😂.

Fixes #276 