### PR TITLE
Remove extraneous 'new' from quick-start

### DIFF
--- a/hygen.io/docs/quick-start.md
+++ b/hygen.io/docs/quick-start.md
@@ -85,7 +85,7 @@ Loaded templates: src/templates
 This creates a project-local `_templates` folder for you at your source root with two helper generators that saves you time:
 
 * `hygen generator new generatorName` - builds a new generator for you
-* `hygen generator with-prompt new generatorName` - the same as before, only this one will be prompt driven.
+* `hygen generator with-prompt generatorName` - the same as before, only this one will be prompt driven.
 
 [[info]]
 |###### Template Locality


### PR DESCRIPTION
Just a small docs fix!