### PR TITLE
Keep readme up-to-date for version 6.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,14 +305,14 @@ as a dependency and having [this kind of workflow](src/bin.ts) in your binary.
 
 ```javascript
 const { runner } = require('hygen')
-const Logger = require('hygen/lib/logger')
+const Logger = require('hygen/dist/logger')
 const path = require('path')
 const defaultTemplates = path.join(__dirname, 'templates')
 
 runner(process.argv.slice(2), {
   templates: defaultTemplates,
   cwd: process.cwd(),
-  logger: new Logger(console.log.bind(console)),
+  logger: new Logger.default(console.log.bind(console)),
   createPrompter: () => require('enquirer'),
   exec: (action, body) => {
     const opts = body && body.length > 0 ? { input: body } : {}


### PR DESCRIPTION
Version 6.2.0 changed some files around in the npm package. The `lib` directory has been superseded by the `dist` directory, and `Logger` itself is not a constructor. These were the changes I needed to make to get my thing working with version 6.2.0. 