### PR TITLE
fix(config-resolver): it uses templates from config when explicitly p…

### DIFF
--- a/src/config-resolver.ts
+++ b/src/config-resolver.ts
@@ -13,9 +13,10 @@ export default async (config: RunnerConfig): Promise<RunnerConfig> => {
   const { cwd, templates } = config
 
   const resolvedTemplates =
+    templates ||
     [process.env.HYGEN_TMPLS, path.join(cwd, '_templates')].find(
       (_) => _ && fs.existsSync(_),
-    ) || templates
+    )
 
   return {
     ...config,


### PR DESCRIPTION
When using `hygen` as a standalone script in conjunction with `yarn create something`,  `npm create something`, etc `hygen` fails to read custom templates passed in the `config` param. 

The reason is because `config.templates` is applied only if the first condition is falsy, which is not the case using global `yarn create`, etc. In this case ` path.join(cwd, '_templates')]` is always resolved to the default `hygen` _templates and actions (generator help, generator new, generator with-prompt).

```
const resolvedTemplates =
    [process.env.HYGEN_TMPLS, path.join(cwd, '_templates')].find(
      (_) => _ && fs.existsSync(_),
    ) || templates // 👈
```

I think it would make more sense to first apply `config.templates` if they are explicitly passed:

```
 const resolvedTemplates =
    templates || // 👈
    [process.env.HYGEN_TMPLS, path.join(cwd, '_templates')].find(
      (_) => _ && fs.existsSync(_),
    )
```