### PR TITLE
docs: fix unsecure links and align format

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@
 
 ## Quick Start
 
-Hygen can be used to supercharge your workflow with [Redux](http://www.hygen.io/docs/redux), [React Native](http://www.hygen.io/docs/react-native), [Express](http://www.hygen.io/docs/express) and more, by allowing you avoid manual work and generate, add, inject and perform custom operations on your codebase.
+Hygen can be used to supercharge your workflow with [Redux](https://hygen.io/docs/redux), [React Native](https://hygen.io/docs/react-native), [Express](https://hygen.io/docs/express) and more, by allowing you avoid manual work and generate, add, inject and perform custom operations on your codebase.
 
 If you're on macOS and have Homebrew:
 
@@ -136,13 +136,13 @@ $ hygen init repo antfu/vitesse
 
 ## What's Next?
 
-Go to the [documentation](http://www.hygen.io/docs/quick-start) to get to know the rest of Hygen and generators.
+Go to the [documentation](https://hygen.io/docs/quick-start) to get to know the rest of Hygen and generators.
 
 If you're in a hurry:
 
-* To learn how to edit generator templates, [look here](http://www.hygen.io/docs/templates)
-* To see how to use generators [look here](http://www.hygen.io/docs/generators)
-* Take a look at the [ecosystem](http://www.hygen.io/docs/packages) and tooling built around Hygen.
+* To learn how to edit generator templates, [look here](https://hygen.io/docs/templates)
+* To see how to use generators [look here](https://hygen.io/docs/generators)
+* Take a look at the [ecosystem](https://hygen.io/docs/packages) and tooling built around Hygen.
 
 ## A Different Kind of a Generator
 

--- a/dist/engine.js
+++ b/dist/engine.js
@@ -70,7 +70,7 @@ Options:
       1. 'hygen init self' to initialize your project, and
       2. 'hygen generator new --name ${generator}' to build the generator you wanted.
 
-      Check out the quickstart for more: http://www.hygen.io/docs/quick-start
+      Check out the quickstart for more: https://hygen.io/docs/quick-start
       `);
     }
     // lazy loading these dependencies gives a better feel once

--- a/dist/help.js
+++ b/dist/help.js
@@ -40,7 +40,7 @@ const printHelp = (templates, logger) => {
 
       $ hygen my-generator 
 
-      See http://hygen.io for more.
+      See https://hygen.io for more.
       
       `);
         return;

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -52,7 +52,7 @@ Options:
       1. 'hygen init self' to initialize your project, and
       2. 'hygen generator new --name ${generator}' to build the generator you wanted.
 
-      Check out the quickstart for more: http://www.hygen.io/docs/quick-start
+      Check out the quickstart for more: https://hygen.io/docs/quick-start
       `);
     } // lazy loading these dependencies gives a better feel once
     // a user is exploring hygen (not specifying what to execute)

--- a/lib/help.js
+++ b/lib/help.js
@@ -36,7 +36,7 @@ const printHelp = (templates, logger) => {
 
       $ hygen my-generator 
 
-      See http://hygen.io for more.
+      See https://hygen.io for more.
       
       `);
     return;

--- a/scripts/standalone.js
+++ b/scripts/standalone.js
@@ -71,7 +71,7 @@ SHA = "${sha}"
 
 class Hygen < Formula
   desc "The scalable code generator that saves you time."
-  homepage "http://www.hygen.io"
+  homepage "https://hygen.io"
   url "https://github.com/jondot/hygen/releases/download/v#{VER}/hygen.macos.v#{VER}.tar.gz"
   version VER
   sha256 SHA

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -45,7 +45,7 @@ Options:
       1. 'hygen init self' to initialize your project, and
       2. 'hygen generator new --name ${generator}' to build the generator you wanted.
 
-      Check out the quickstart for more: http://www.hygen.io/docs/quick-start
+      Check out the quickstart for more: https://hygen.io/docs/quick-start
       `)
   }
 

--- a/src/help.ts
+++ b/src/help.ts
@@ -36,7 +36,7 @@ const printHelp = (templates: string, logger: Logger) => {
 
       $ hygen my-generator 
 
-      See http://hygen.io for more.
+      See https://hygen.io for more.
       
       `)
     return


### PR DESCRIPTION
I found several unsecure links without SSL enabled. Also aligned the url scheme of the hygen homepage referenced in the docs and doc strings across the project. There is one left in the repository description, which is still pointing to **http://hygen.io** which may be changed into **https://hygen.io**, too.