### PR TITLE
Expose helpers defined in hygen.js in params and prompt hooks

### DIFF
--- a/src/__tests__/__snapshots__/metaverse.spec.ts.snap
+++ b/src/__tests__/__snapshots__/metaverse.spec.ts.snap
@@ -15,6 +15,36 @@ Object {
 }
 `;
 
+exports[`metaverse hygen-extension: helpers-in-params new --name person 1`] = `
+Object {
+  "actions": Array [
+    Object {
+      "status": "added",
+      "subject": "given/helpers-in-params/new.md",
+      "timing": -1,
+      "type": "add",
+    },
+  ],
+  "success": true,
+  "time": 0,
+}
+`;
+
+exports[`metaverse hygen-extension: helpers-in-prompt new 1`] = `
+Object {
+  "actions": Array [
+    Object {
+      "status": "added",
+      "subject": "given/helpers-in-prompt/new.md",
+      "timing": -1,
+      "type": "add",
+    },
+  ],
+  "success": true,
+  "time": 0,
+}
+`;
+
 exports[`metaverse hygen-extension: hygen-js new 1`] = `
 Object {
   "actions": Array [

--- a/src/__tests__/metaverse.spec.ts
+++ b/src/__tests__/metaverse.spec.ts
@@ -10,7 +10,15 @@ describe('metaverse', () => {
     enquirer.prompt = failPrompt
   })
   metaverse('hygen-defaults', [['use-defaults']], { overwrite: true })
-  metaverse('hygen-extension', [['hygen-js', 'new']], { overwrite: true })
+  metaverse(
+    'hygen-extension',
+    [
+      ['hygen-js', 'new'],
+      ['helpers-in-prompt', 'new'],
+      ['helpers-in-params', 'new', '--name', 'person'],
+    ],
+    { overwrite: true, name: 'messages' },
+  )
 
   metaverse(
     'hygen-templates',

--- a/src/__tests__/metaverse/hygen-extension/_templates/helpers-in-params/new/index.ejs.t
+++ b/src/__tests__/metaverse/hygen-extension/_templates/helpers-in-params/new/index.ejs.t
@@ -1,0 +1,5 @@
+---
+to: given/helpers-in-params/new.md
+---
+this demonstrates hygen loaded up .hygen.js and extended helpers in params.
+<%= upperName %>

--- a/src/__tests__/metaverse/hygen-extension/_templates/helpers-in-params/new/index.js
+++ b/src/__tests__/metaverse/hygen-extension/_templates/helpers-in-params/new/index.js
@@ -1,0 +1,5 @@
+module.exports = {
+  params: ({ args, h }) => {
+    return { upperName: h.extended(args.name) }
+  },
+}

--- a/src/__tests__/metaverse/hygen-extension/_templates/helpers-in-prompt/new/index.ejs.t
+++ b/src/__tests__/metaverse/hygen-extension/_templates/helpers-in-prompt/new/index.ejs.t
@@ -1,0 +1,5 @@
+---
+to: given/helpers-in-prompt/new.md
+---
+this demonstrates hygen loaded up .hygen.js and extended helpers in prompt.
+<%= upperName %>

--- a/src/__tests__/metaverse/hygen-extension/_templates/helpers-in-prompt/new/prompt.js
+++ b/src/__tests__/metaverse/hygen-extension/_templates/helpers-in-prompt/new/prompt.js
@@ -1,0 +1,12 @@
+module.exports = {
+  prompt: ({ prompter, h }) =>
+    prompter
+      .prompt({
+        type: 'input',
+        name: 'name',
+        message: "What's your name?",
+      })
+      .then(({ name }) => {
+        return { upperName: h.extended(name) }
+      }),
+}

--- a/src/__tests__/metaverse/hygen-extension/expected/helpers-in-params/new.md
+++ b/src/__tests__/metaverse/hygen-extension/expected/helpers-in-params/new.md
@@ -1,0 +1,2 @@
+this demonstrates hygen loaded up .hygen.js and extended helpers in params.
+PERSON

--- a/src/__tests__/metaverse/hygen-extension/expected/helpers-in-prompt/new.md
+++ b/src/__tests__/metaverse/hygen-extension/expected/helpers-in-prompt/new.md
@@ -1,0 +1,2 @@
+this demonstrates hygen loaded up .hygen.js and extended helpers in prompt.
+MESSAGES

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,5 +1,5 @@
 import type { RunnerConfig } from './types'
-import helpers from './helpers'
+import { capitalize, createHelpers, inflection } from './helpers'
 
 const localsToCapitalize = ['name']
 const localsToPluralize = ['name']
@@ -11,14 +11,14 @@ const processLocals = (hsh, [key, value]) => {
   hsh[key] = value
 
   if (localsToCapitalize.includes(key)) {
-    hsh[helpers.capitalize(key)] = helpers.capitalize(value)
+    hsh[capitalize(key)] = capitalize(value)
   }
 
   if (localsToPluralize.includes(key)) {
-    hsh[helpers.inflection.pluralize(key)] = helpers.inflection.pluralize(value)
-    hsh[
-      helpers.capitalize(helpers.inflection.pluralize(key))
-    ] = helpers.capitalize(helpers.inflection.pluralize(value))
+    hsh[inflection.pluralize(key)] = inflection.pluralize(value)
+    hsh[capitalize(inflection.pluralize(key))] = capitalize(
+      inflection.pluralize(value),
+    )
   }
 
   return hsh
@@ -33,17 +33,12 @@ const context = (locals: any, config: RunnerConfig = {}) => {
     ...config.localsDefaults,
     ...locals,
   }
-  const configHelpers =
-    (config &&
-      (typeof config.helpers === 'function'
-        ? config.helpers(locals, config)
-        : config.helpers)) ||
-    {}
+
   return Object.assign(
     localsWithDefaults,
     processedLocals(localsWithDefaults),
     {
-      h: { ...helpers, ...configHelpers },
+      h: createHelpers(locals, config),
     },
   )
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,6 +1,7 @@
 import path from 'path'
 import inflection from 'inflection'
 import changeCase from 'change-case'
+import type { RunnerConfig } from './types'
 
 // supports kebab-case to KebabCase
 inflection.undasherize = (str) =>
@@ -9,14 +10,26 @@ inflection.undasherize = (str) =>
     .map((w) => w[0].toUpperCase() + w.slice(1).toLowerCase())
     .join('')
 
-const helpers = {
-  capitalize(str) {
-    const toBeCapitalized = String(str)
-    return toBeCapitalized.charAt(0).toUpperCase() + toBeCapitalized.slice(1)
-  },
+const capitalize = (str) => {
+  const toBeCapitalized = String(str)
+  return toBeCapitalized.charAt(0).toUpperCase() + toBeCapitalized.slice(1)
+}
+
+const globalHelpers = {
+  capitalize,
   inflection,
   changeCase,
   path,
 }
 
-export default helpers
+const createHelpers = (locals: any, config: RunnerConfig): any => {
+  const configHelpers =
+    (config &&
+      (typeof config.helpers === 'function'
+        ? config.helpers(locals, config)
+        : config.helpers)) ||
+    {}
+  return { ...globalHelpers, ...configHelpers }
+}
+
+export { capitalize, createHelpers, inflection }

--- a/src/params.ts
+++ b/src/params.ts
@@ -45,9 +45,10 @@ const resolvePositionals = async (templates: string, args: string[]) => {
 }
 
 const params = async (
-  { templates, createPrompter }: RunnerConfig,
+  config: RunnerConfig,
   externalArgv: string[],
 ): Promise<ParamsResult> => {
+  const { templates, createPrompter } = config
   const argv = yargs(externalArgv)
 
   const [generator, action, name] = await resolvePositionals(templates, argv._)
@@ -60,12 +61,17 @@ const params = async (
   const actionfolder = path.join(templates, generator, mainAction)
 
   const { _, ...cleanArgv } = argv
-  const promptArgs = await prompt(createPrompter, actionfolder, {
-    // NOTE we might also want the rest of the generator/action/etc. params here
-    // but theres no usecase yet
-    ...(name ? { name } : {}),
-    ...cleanArgv,
-  })
+  const promptArgs = await prompt(
+    createPrompter,
+    actionfolder,
+    {
+      // NOTE we might also want the rest of the generator/action/etc. params here
+      // but theres no usecase yet
+      ...(name ? { name } : {}),
+      ...cleanArgv,
+    },
+    config,
+  )
 
   const args = Object.assign(
     {

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -1,7 +1,7 @@
 import path from 'path'
 import fs from 'fs'
-import type { Prompter } from './types'
-import helpers from './helpers'
+import type { Prompter, RunnerConfig } from './types'
+import { createHelpers } from './helpers'
 
 const hooksfiles = [
   'index.js',
@@ -14,6 +14,7 @@ const prompt = async <Q, T>(
   createPrompter: () => Prompter<Q, T>,
   actionfolder: string,
   args: Record<string, any>,
+  config: RunnerConfig,
 ): Promise<T | object> => {
   const hooksfile = hooksfiles
     .map((f) => path.resolve(path.join(actionfolder, f)))
@@ -34,8 +35,10 @@ const prompt = async <Q, T>(
     hooksModule = hooksModule.default
   }
 
+  const h = createHelpers({}, config)
+
   if (hooksModule.params) {
-    return hooksModule.params({ args, h: helpers })
+    return hooksModule.params({ args, h })
   }
 
   // lazy loads prompter
@@ -46,7 +49,7 @@ const prompt = async <Q, T>(
       prompter,
       inquirer: prompter,
       args,
-      h: helpers,
+      h,
     })
   }
 


### PR DESCRIPTION
This is a followup to #326 

Currently the helpers defined in hygen.js are available only in templates

With this PR is available also in params and prompt hooks

This follows DRY principle by allowing to define helpers in only one place 