### PR TITLE
Replace a block with a template between 'after' and 'before' or 'line_at'

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,10 @@ You can guard against double injection:
 
 * `skip_if` - a regular expression / text. If exists injection is skipped.
 
+You can replace all the contents (a block) between different positions using:
+
+* `after` and `before`, or `line_at` and `after` or `before`
+
 Also you can insert or remove empty line to injection body. That feature very useful if your editor or formatter automatically insert blank line at the end of file on save:
 
 * `eof_last` - if falsy - trim blank line from the end of injection body, if truthy - insert it.

--- a/dist/ops/injector.js
+++ b/dist/ops/injector.js
@@ -32,13 +32,13 @@ const locations = {
     before: (_, lines) => getPragmaticIndex(_, lines, true),
     after: (_, lines) => getPragmaticIndex(_, lines, false),
 };
-const indexByLocation = (attributes, lines) => {
-    const pair = Object.entries(attributes).find(([k, _]) => locations[k]);
-    if (pair) {
+const indexesByLocation = (attributes, lines) => {
+    const pairs = Object.entries(attributes).filter(([k, _]) => locations[k]);
+    pairs.forEach((pair, i) => {
         const [k, v] = pair;
-        return locations[k](v, lines);
-    }
-    return -1;
+        pairs[i] = locations[k](v, lines);
+    })
+    return pairs;
 };
 const injector = (action, content) => {
     const { attributes: { skip_if, eof_last }, attributes, body, } = action;

--- a/hygen.io/docs/templates.md
+++ b/hygen.io/docs/templates.md
@@ -289,6 +289,10 @@ Here are the available properties for an `inject: true` template:
 * `prepend` or `append`, when true, add a line to start or end of file respectively.
 * `at_line` which contains a line number will add a line at this exact line number.
 
+You can replace all the contents (a block) between different positions using:
+
+* `after` and `before`, or `at_line` and `after` or `before`
+
 In almost all cases you want to ensure you're not injecting content twice:
 
 * `skip_if` which contains a regular expression / text. If exists, injection is skipped.

--- a/src/__tests__/__snapshots__/injector.spec.ts.snap
+++ b/src/__tests__/__snapshots__/injector.spec.ts.snap
@@ -44,6 +44,16 @@ exports[`injector before rails 1`] = `
     "
 `;
 
+exports[`injector between rails 1`] = `
+"
+    source 'http://rubygems.org'
+    gem 'rails'
+    gem 'kamikaze' # added by hygen
+    gem 'httparty'
+
+    "
+`;
+
 exports[`injector correctly interpret multi-line after regex 1`] = `
 "
     source 'http://rubygems.org'

--- a/src/__tests__/injector.spec.ts
+++ b/src/__tests__/injector.spec.ts
@@ -34,6 +34,20 @@ describe('injector', () => {
       ),
     ).toMatchSnapshot()
   })
+  it('between rails', () => {
+    expect(
+      injector(
+        {
+          attributes: {
+            after: "gem 'rails'",
+            before: "gem 'httparty'",
+          },
+          body: "    gem 'kamikaze' # added by hygen",
+        },
+        gemfile,
+      ),
+    ).toMatchSnapshot()
+  })
   it('prepend top of file', () => {
     expect(
       injector(


### PR DESCRIPTION
This way one could update the accessors inside a class definition, while protecting custom parts of the class from overwriting.