### PR TITLE
fix(shell): Improve error message output

### DIFF
--- a/dist/ops/shell.js
+++ b/dist/ops/shell.js
@@ -30,7 +30,7 @@ const shell = ({ attributes: { sh, spinner, sh_ignore_exit }, body }, args, { lo
             }
             catch (error) {
                 if (sh_ignore_exit !== true) {
-                    logger.err(error.stderr);
+                    logger.err(error.stderr || error.stdout);
                     process.exit(1);
                 }
             }

--- a/src/ops/shell.ts
+++ b/src/ops/shell.ts
@@ -21,7 +21,7 @@ const shell = async (
         debug('result %o', res)
       } catch (error) {
         if (sh_ignore_exit !== true) {
-          logger.err(error.stderr)
+          logger.err(error.stderr || error.stdout)
           process.exit(1)
         }
       } finally {


### PR DESCRIPTION
I found some `sh` failed without `stderr` message, instead they are output to `stdout`, e.g. `pnpm i` while `package.json`'s syntax error.

