### PR TITLE
Fix meta description

### DIFF
--- a/hygen.io/src/pages/index.js
+++ b/hygen.io/src/pages/index.js
@@ -17,7 +17,7 @@ function Home() {
   return (
     <Layout
       title={siteConfig.title}
-      description="Description will go into a meta tag in <head />"
+      description={siteConfig.tagline}
     >
       <IndexHeadContainer>
         <Hero>


### PR DESCRIPTION
Meta description is currently `Description will go into a meta tag in <head />` 😅

https://bsky.app/profile/nicoespeon.com/post/3laono3qzq22z

![Screenshot 2024-11-11 at 18 05 53](https://github.com/user-attachments/assets/42baa678-e44a-44e1-bcd0-3f96fe68ed51)


It's funny, but I guess it's an unintentional mistake?

Was thinking maybe the Docusaurus `tagline` could fit here:

https://github.com/jondot/hygen/blob/a026b423d4d66fef82cb1000bf6c64b50d991a19/my-website/docusaurus.config.js#L1-L3